### PR TITLE
Add basic Node.js test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "echo 'No tests yet'"
+    "test": "node --test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -29,6 +29,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/node": "^20.0.0",
     "tailwindcss": "^3.3.3",
     "postcss": "^8.4.31",
     "autoprefixer": "^10.4.14"

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('基本的な算術', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- enable `npm test` by using Node.js built-in test runner
- add an example test verifying basic arithmetic
- include `@types/node` in dev dependencies

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'vite')*


------
https://chatgpt.com/codex/tasks/task_e_68c50e528c74832f9f0c85a8b4ad0894